### PR TITLE
S3をDBとして使ってみる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'aws-sdk-s3'
 gem 'aws-sdk-lambda'
 gem 'aws-sdk-dynamodb'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,15 @@ GEM
     aws-sdk-dynamodb (1.58.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
+    aws-sdk-kms (1.41.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-lambda (1.57.0)
       aws-sdk-core (~> 3, >= 3.109.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.87.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
+      aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
@@ -39,6 +46,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-dynamodb
   aws-sdk-lambda
+  aws-sdk-s3
   line-bot-api
   nokogiri
   pry-byebug

--- a/app/modules/kosodate_events_scraper.rb
+++ b/app/modules/kosodate_events_scraper.rb
@@ -1,5 +1,6 @@
 require 'nokogiri'
 require 'open-uri'
+require 'aws-sdk-s3'
 require "pry"
 require_relative '../models/kosodate_event.rb'
 
@@ -58,9 +59,11 @@ class KosodateEventsScraper
         end
       end
 
-      KosodateEvent.bulk_insert(events)
-      # ここでbulk-insertすべきでは？
-      # KosodateEvent.create(event)って変
+      s3_client = Aws::S3::Client.new(region: 'ap-northeast-1')
+      buckets = s3_client.list_buckets.buckets
+      bucket = buckets.find {|bucket| bucket.name.start_with?('musashino-kosodate-events')}
+      # TODO: jsonファイルを作って置く
+
       [year_month, events]
     end
   end

--- a/serverless.yml
+++ b/serverless.yml
@@ -113,6 +113,10 @@ functions:
 # you can add CloudFormation resource templates here
 resources:
   Resources:
+    Bucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: musashino-kosodate-events-${self:provider.stage}
     DynamoDbTable:
       Type: 'AWS::DynamoDB::Table'
       Properties:


### PR DESCRIPTION
## 概要
複数件一括のdelete -> putのトランザクション管理が、DynamoDBだと複雑になりそう。

S3で月ごとにJSONファイルで持つようにすれば、更新前/更新後のいずれかにしかならないAtomicな状態になる。
S3の懸念はパフォーマンスなので、試しに実装して確認する。

## やること
- [x] install `aws-sdk-s3` 
- [x] serverless.ymlにs3追記
- [ ] S3の読み書き
- [ ] LINE botで検証