### PR TITLE
bundler-cacheで十分なので

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,4 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Test with Rspec
-      run: |
-        gem install bundler
-        bundle install --path vendor/bundle
-        bundle exec rspec
+      run: bundle exec rspec


### PR DESCRIPTION
GitHub Actionsの設定を編集。
`bundler-cache: true`なら`bundle install`されるので、明示的に書く必要は無い。