### PR TITLE
カレンダーと親子ひろばの情報を統合する

### DIFF
--- a/app/lambda/scraper_function.rb
+++ b/app/lambda/scraper_function.rb
@@ -1,6 +1,10 @@
 require 'aws-sdk-dynamodb'
-require_relative '../modules/scrapers/calendar_scraper.rb'
+require_relative '../modules/kosodate_event_integrator.rb'
 
 def run(event:, context:)
-  CalendarScraper.run
+  # 今月
+  KosodateEventIntegrator.run
+
+  # 来月
+  KosodateEventIntegrator.run(next_month: true)
 end

--- a/app/models/kosodate_event.rb
+++ b/app/models/kosodate_event.rb
@@ -16,7 +16,7 @@ class KosodateEvent
   def save!
     item = {
       date: formatted_date,
-      name: name,
+      name: formatted_name,
       place: place,
       url: url,
       booking_required: booking_required
@@ -27,6 +27,14 @@ class KosodateEvent
 
   def formatted_date
     date.strftime('%Y-%m-%d')
+  end
+
+  def formatted_name
+    oyako_hiroba? ? "#{name}_#{place}" : name
+  end
+
+  def oyako_hiroba?
+    name == "コミセン親子ひろば"
   end
 
   class << self
@@ -52,7 +60,7 @@ class KosodateEvent
       events.map! do |event|
         {
           date: event.formatted_date,
-          name: event.name,
+          name: event.formatted_name,
           place: event.place,
           url: event.url,
           booking_required: event.booking_required
@@ -79,11 +87,20 @@ class KosodateEvent
     # KosodateEventインスタンスに変換する
     def parse(items)
       items.map do |item|
+        name = remove_place(item["name"])
         new(date: Date.parse(item["date"]),
-            name: item["name"],
+            name: name,
             place: item["place"],
             url: item["url"],
             booking_required: item["booking_required"])
+      end
+    end
+
+    def remove_place(name)
+      if name.start_with?("コミセン親子ひろば")
+        "コミセン親子ひろば"
+      else
+        name
       end
     end
   end

--- a/app/modules/kosodate_event_integrator.rb
+++ b/app/modules/kosodate_event_integrator.rb
@@ -1,0 +1,11 @@
+class KosodateEventIntegrator
+  class << self
+    def run
+      # CalendarScraper.run
+      # OyakoHirobaScraper.run
+      # 重複したら場所だけ追加
+
+      # KosodateEvent.bulk_insert
+    end
+  end
+end

--- a/app/modules/kosodate_event_integrator.rb
+++ b/app/modules/kosodate_event_integrator.rb
@@ -1,11 +1,11 @@
 class KosodateEventIntegrator
   class << self
     def run
-      # CalendarScraper.run
-      # OyakoHirobaScraper.run
+      events = CalendarScraper.run + OyakoHirobaScraper.run
+
       # 重複したら場所だけ追加
 
-      # KosodateEvent.bulk_insert
+      KosodateEvent.bulk_insert(events)
     end
   end
 end

--- a/app/modules/kosodate_event_integrator.rb
+++ b/app/modules/kosodate_event_integrator.rb
@@ -1,8 +1,11 @@
+require_relative "scrapers/calendar_scraper.rb"
+require_relative "scrapers/oyako_hiroba_scraper.rb"
+
 class KosodateEventIntegrator
   class << self
-    def run
-      calendar = CalendarScraper.run
-      oyako_hiroba = OyakoHirobaScraper.run
+    def run(next_month: false)
+      calendar = CalendarScraper.run(next_month: next_month)
+      oyako_hiroba = OyakoHirobaScraper.run(next_month: next_month)
 
       events = if calendar_includes_oyako_hiroba?(calendar)
                   add_place(calendar, oyako_hiroba)

--- a/app/modules/scrapers/calendar_scraper.rb
+++ b/app/modules/scrapers/calendar_scraper.rb
@@ -13,7 +13,7 @@ class CalendarScraper
       events = scrape(calendar_table)
       events = convert_to_kosodate_event(events)
 
-      KosodateEvent.bulk_insert(events)
+      events
     end
 
     private

--- a/spec/lambda/scraper_function_spec.rb
+++ b/spec/lambda/scraper_function_spec.rb
@@ -1,8 +1,9 @@
 require_relative '../../app/lambda/scraper_function.rb'
 
 RSpec.describe 'Lambda scraper_function' do
-  describe "run" do
-    it "foo" do
+  describe ".run" do
+    example "とりあえず例外が出ないことの確認" do
+      run(event: nil, context: nil)
     end
   end
 end

--- a/spec/modules/kosodate_event_integrator_spec.rb
+++ b/spec/modules/kosodate_event_integrator_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../app/modules/kosodate_event_integrator.rb'
+
+RSpec.describe KosodateEventIntegrator do
+  describe ".run" do
+  end
+end
+

--- a/spec/modules/kosodate_event_integrator_spec.rb
+++ b/spec/modules/kosodate_event_integrator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe KosodateEventIntegrator do
       allow(OyakoHirobaScraper).to receive(:run).and_return([oyako_hiroba_event])
 
       KosodateEventIntegrator.run 
-      
+
       events = KosodateEvent.all
       expect(events.count).to eq(1)
 

--- a/spec/modules/kosodate_event_integrator_spec.rb
+++ b/spec/modules/kosodate_event_integrator_spec.rb
@@ -1,7 +1,19 @@
 require_relative '../../app/modules/kosodate_event_integrator.rb'
+require_relative '../../app/modules/scrapers/calendar_scraper.rb'
+require_relative '../../app/modules/scrapers/oyako_hiroba_scraper.rb'
 
 RSpec.describe KosodateEventIntegrator do
   describe ".run" do
+    example "イベント情報を統合する" do
+      calendar_events = build_list(:kosodate_event, 5, name: "ちびっこランド")
+      allow(CalendarScraper).to receive(:run).and_return(calendar_events)
+
+      oyako_hiroba_events = build_list(:kosodate_event, 5, name: "コミセン親子ひろば")
+      allow(OyakoHirobaScraper).to receive(:run).and_return(oyako_hiroba_events)
+
+      KosodateEventIntegrator.run
+      expect(KosodateEvent.all.count).to eq(10)
+    end
   end
 end
 

--- a/spec/modules/kosodate_event_integrator_spec.rb
+++ b/spec/modules/kosodate_event_integrator_spec.rb
@@ -4,15 +4,26 @@ require_relative '../../app/modules/scrapers/oyako_hiroba_scraper.rb'
 
 RSpec.describe KosodateEventIntegrator do
   describe ".run" do
-    example "イベント情報を統合する" do
-      calendar_events = build_list(:kosodate_event, 5, name: "ちびっこランド")
-      allow(CalendarScraper).to receive(:run).and_return(calendar_events)
+    example "親子ひろばがすでにカレンダーにある場合は、場所だけ追加する" do
+      name = "コミセン親子ひろば"
+      place = "吉祥寺東"
+      calendar_event = build(:kosodate_event, date: Date.today, name: name)
+      oyako_hiroba_event = build(:kosodate_event, date: Date.today, name: name, place: place)
 
-      oyako_hiroba_events = build_list(:kosodate_event, 5, name: "コミセン親子ひろば")
-      allow(OyakoHirobaScraper).to receive(:run).and_return(oyako_hiroba_events)
+      allow(CalendarScraper).to receive(:run).and_return([calendar_event])
+      allow(OyakoHirobaScraper).to receive(:run).and_return([oyako_hiroba_event])
 
-      KosodateEventIntegrator.run
-      expect(KosodateEvent.all.count).to eq(10)
+      KosodateEventIntegrator.run 
+      
+      events = KosodateEvent.all
+      expect(events.count).to eq(1)
+
+      event = events.first
+      expect(event.name).to eq(name)
+      expect(event.place).to eq(place)
+    end
+
+    example "親子ひろばが無い場合は、イベントそのものを追加する" do
     end
   end
 end

--- a/spec/modules/kosodate_event_integrator_spec.rb
+++ b/spec/modules/kosodate_event_integrator_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe KosodateEventIntegrator do
     end
 
     example "親子ひろばが無い場合は、イベントそのものを追加する" do
+      calendar_event = build(:kosodate_event, date: Date.today, name: "児童館・3月トランポリンの日")
+      oyako_hiroba_event = build(:kosodate_event, date: Date.today, name: "コミセン親子ひろば", place: "吉祥寺東")
+
+      allow(CalendarScraper).to receive(:run).and_return([calendar_event])
+      allow(OyakoHirobaScraper).to receive(:run).and_return([oyako_hiroba_event])
+
+      KosodateEventIntegrator.run
+
+      events = KosodateEvent.all
+      expect(events.count).to eq(2)
     end
   end
 end

--- a/spec/modules/scrapers/calendar_scraper_spec.rb
+++ b/spec/modules/scrapers/calendar_scraper_spec.rb
@@ -3,9 +3,9 @@ require_relative '../../../app/modules/scrapers/calendar_scraper.rb'
 RSpec.describe CalendarScraper do
   describe ".run" do
     example "今月の子育てイベント情報を取得する" do
-      CalendarScraper.run
+      events = CalendarScraper.run
 
-      event = KosodateEvent.all.first
+      event = events.first
       expect(event).to be_a_instance_of(KosodateEvent)
       expect(event.date.month).to eq(Date.today.month)
     end


### PR DESCRIPTION
## やったこと
- [x] CalendarScraperもKosodateEventオブジェクトの配列を返す
- [x] OyakoHirobaScraperとCalendarScraperの情報を統合するクラスを作る
- [x] scraper_functionはそれだけを呼び出す
- [x] コミセン親子ひろばは`#{name}_#{place}`で永続化（同日開催があるため）
- [x] dev, prodへデプロイ