### PR TITLE
メッセージのフォーマット処理を共通化

### DIFF
--- a/app/lambda/line_bot_function.rb
+++ b/app/lambda/line_bot_function.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'line/bot'
+require_relative '../modules/reply_formatter.rb'
 
 def client
   @client ||= Line::Bot::Client.new { |config|
@@ -22,6 +23,7 @@ def answer(event:, context:)
       case event.type
       # テキストだったとき
       when Line::Bot::Event::MessageType::Text
+
         message = {
           type: 'text',
           text: event.message['text'] # 同じ言葉を返す

--- a/app/lambda/notifier_function.rb
+++ b/app/lambda/notifier_function.rb
@@ -1,7 +1,7 @@
 require 'json'
 require 'line/bot'
 require_relative '../models/kosodate_event.rb'
-require_relative '../modules/broadcast_formatter.rb'
+require_relative '../modules/message_formatter.rb'
 
 def client
   @client ||= Line::Bot::Client.new { |config|
@@ -14,6 +14,6 @@ end
 def run(event:, context:)
   date = Date.today
   events = KosodateEvent.where(year: date.year, month: date.month)
-  messages = BroadcastFormatter.format(events)
+  messages = MessageFormatter.format(events)
   client.broadcast(messages)
 end

--- a/app/modules/message_formatter.rb
+++ b/app/modules/message_formatter.rb
@@ -1,4 +1,4 @@
-class BroadcastFormatter
+module MessageFormatter
   DAYS_OF_THE_WEEK = %w(日 月 火 水 木 金 土)
   DEVIDING_LINE = "\n--------------------------------------\n\n"
   BOOKING_REQUIRED = '【事前申込必要】'
@@ -8,9 +8,7 @@ class BroadcastFormatter
       schedule = events.group_by{ |event| event.date }.sort
 
       formatted_schedule = schedule.map do |date, event_items|
-        event_items.map! do |event|
-          "\n#{event.name} #{BOOKING_REQUIRED if event.booking_required} \n#{event.url}\n" 
-        end
+        event_items.map! { |event| build_event_detail(event) }
         
         day_of_the_week = DAYS_OF_THE_WEEK[date.strftime('%w').to_i]
         display_date = date.strftime('%-m月%-d日') + '(' + day_of_the_week + ')' # 例 2月1日(月)
@@ -20,20 +18,23 @@ class BroadcastFormatter
 
       formatted_message(formatted_schedule)
     end
-    
+
     private
 
+    def build_event_detail(event)
+      "\n#{event.name} #{BOOKING_REQUIRED if event.booking_required} \n#{event.url}\n" 
+    end
+
     def formatted_message(schedule)
-      [{
-        type: 'text',
-        text: schedule[0..9].join(DEVIDING_LINE)
-      },{
-        type: 'text',
-        text: schedule[10..19].join(DEVIDING_LINE)
-      },{
-        type: 'text',
-        text: schedule[20..30].join(DEVIDING_LINE)
-      }]
+      message = []
+      schedule.each_slice(10) do |dates|
+        message << {
+          type: 'text',
+          text: dates.join(DEVIDING_LINE)
+        }
+      end
+
+      message
     end
   end
 end

--- a/app/modules/reply_formatter.rb
+++ b/app/modules/reply_formatter.rb
@@ -3,9 +3,11 @@ module ReplyFormatter
     "今月" => Date.today.month,
     "来月" => Date.today.next_month.month
   }
-  def format(text)
-    # 検索
-    # 日付、場所名を探して
-    
+
+  class << self
+    def format(text)
+      # 検索
+      # 日付、場所名を探して
+    end
   end
 end

--- a/app/modules/reply_formatter.rb
+++ b/app/modules/reply_formatter.rb
@@ -1,0 +1,11 @@
+module ReplyFormatter
+  MAPPING = {
+    "今月" => Date.today.month,
+    "来月" => Date.today.next_month.month
+  }
+  def format(text)
+    # 検索
+    # 日付、場所名を探して
+    
+  end
+end

--- a/spec/lambda/line_bot_function_spec.rb
+++ b/spec/lambda/line_bot_function_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../../app/lambda/line_bot_function.rb'
+
+RSpec.describe 'Lambda line_bot_function' do
+  describe ".run" do
+    example "とりあえず例外が出ないことの確認" do
+      event = {
+        "body" =>  {
+          "events":[
+            {
+              "type":"message",
+              "replyToken":"5d80a999899c4725b88a6bb045f7000",
+              "source":{
+                "userId":"U83d87a70283f1a1d40021aa0d0000000",
+                "type":"user"
+              },
+              "timestamp":1615182250115,
+              "mode":"active",
+              "message":{
+                "type":"text",
+                "id":"13679588938950",
+                "text":"てす"
+              }
+            }
+          ],
+          "destination":"Ue909df35bca265c9c3714d97000000"
+        }.to_json,
+        "replyToken": "hoge"
+      }
+
+      allow_any_instance_of(Line::Bot::Client).to receive(:reply_message)
+      
+      answer(event: event, context: nil)
+    end
+  end
+end

--- a/spec/modules/message_formatter.rb
+++ b/spec/modules/message_formatter.rb
@@ -1,0 +1,14 @@
+require_relative '../../app/modules/message_formatter.rb'
+
+RSpec.describe MessageFormatter do
+  describe ".format" do
+    example "イベント一覧を渡すと、日付区切りのメッセージを作成する" do
+      events = create_list(:kosodate_event, 5, date: Date.today)
+      events += create_list(:kosodate_event, 5, date: (Date.today + 4))
+      events += create_list(:kosodate_event, 5, date: (Date.today + 9))
+      events += create_list(:kosodate_event, 5, date: (Date.today + 14))
+
+      MessageFormatter.format(events)
+    end
+  end
+end

--- a/spec/modules/reply_formatter_spec.rb
+++ b/spec/modules/reply_formatter_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../app/modules/reply_formatter.rb'
+
+RSpec.describe ReplyFormatter do
+  describe ".format" do
+    example "期間で検索" do
+    end
+
+    example "イベント名で検索" do
+    end
+
+    example "場所名で検索" do
+    end
+  end
+end

--- a/spec/modules/reply_formatter_spec.rb
+++ b/spec/modules/reply_formatter_spec.rb
@@ -3,6 +3,9 @@ require_relative '../../app/modules/reply_formatter.rb'
 RSpec.describe ReplyFormatter do
   describe ".format" do
     example "期間で検索" do
+      text = '今月'
+
+      reply = ReplyFormatter.format(text)
     end
 
     example "イベント名で検索" do


### PR DESCRIPTION
## やったこと
- [x] フォーマット処理をMessageFormatterとして共通化

※ 定期通知に加えて、ユーザーからのメッセージへのリプライ作成にも使えるようにするため