### PR TITLE
親子ひろばはカレンダーから除外する

### DIFF
--- a/app/modules/kosodate_event_integrator.rb
+++ b/app/modules/kosodate_event_integrator.rb
@@ -7,29 +7,8 @@ class KosodateEventIntegrator
       calendar = CalendarScraper.run(next_month: next_month)
       oyako_hiroba = OyakoHirobaScraper.run(next_month: next_month)
 
-      events = if calendar_includes_oyako_hiroba?(calendar)
-                  add_place(calendar, oyako_hiroba)
-                else
-                  calendar + oyako_hiroba
-                end
-
+      events = calendar + oyako_hiroba
       KosodateEvent.bulk_insert(events)
-    end
-
-    # 親子ひろばのスケジュールは一括で反映されるため、1件あれば全件あるとみなす
-    def calendar_includes_oyako_hiroba?(events)
-      events.any? { |event| event.name == "コミセン親子ひろば"}
-    end
-
-    def add_place(calendar_events, oyako_hiroba_events)
-      calendar_events.each do |event|
-        next if event.name != "コミセン親子ひろば"
-
-        same_event = oyako_hiroba_events.find { |oyako_event| event.date == oyako_event.date }
-        event.place = same_event.place
-      end
-
-      calendar_events
     end
   end
 end

--- a/app/modules/scrapers/calendar_scraper.rb
+++ b/app/modules/scrapers/calendar_scraper.rb
@@ -12,6 +12,7 @@ class CalendarScraper
 
       events = scrape(calendar_table)
       events = convert_to_kosodate_event(events)
+      events = omit_oyako_hiroba(events)
 
       events
     end
@@ -69,6 +70,11 @@ class CalendarScraper
           booking_required: event[1].text.include?("事前申込必要")
       )
       end
+    end
+
+    # 同日に複数親子ひろばが開催されてもカレンダーは1つしか表示されないため、カレンダーからは除外する
+    def omit_oyako_hiroba(events)
+      events.select {|event| event.name != "コミセン親子ひろば"}
     end
   end
 end

--- a/spec/modules/kosodate_event_integrator_spec.rb
+++ b/spec/modules/kosodate_event_integrator_spec.rb
@@ -4,11 +4,9 @@ require_relative '../../app/modules/scrapers/oyako_hiroba_scraper.rb'
 
 RSpec.describe KosodateEventIntegrator do
   describe ".run" do
-    example "親子ひろばがすでにカレンダーにある場合は、場所だけ追加する" do
-      name = "コミセン親子ひろば"
-      place = "吉祥寺東"
-      calendar_event = build(:kosodate_event, date: Date.today, name: name)
-      oyako_hiroba_event = build(:kosodate_event, date: Date.today, name: name, place: place)
+    example "親子ひろばがあれば、追加する" do
+      calendar_event = build(:kosodate_event, :childrens_center, date: Date.today)
+      oyako_hiroba_event = build(:kosodate_event, :oyako_hiroba, date: Date.today)
 
       allow(CalendarScraper).to receive(:run).and_return([calendar_event])
       allow(OyakoHirobaScraper).to receive(:run).and_return([oyako_hiroba_event])
@@ -16,24 +14,19 @@ RSpec.describe KosodateEventIntegrator do
       KosodateEventIntegrator.run 
 
       events = KosodateEvent.all
-      expect(events.count).to eq(1)
-
-      event = events.first
-      expect(event.name).to eq(name)
-      expect(event.place).to eq(place)
+      expect(events.count).to eq(2)
     end
 
-    example "親子ひろばが無い場合は、イベントそのものを追加する" do
+    example "親子ひろばが無い場合は、カレンダーのみを登録" do
       calendar_event = build(:kosodate_event, date: Date.today, name: "児童館・3月トランポリンの日")
-      oyako_hiroba_event = build(:kosodate_event, date: Date.today, name: "コミセン親子ひろば", place: "吉祥寺東")
 
       allow(CalendarScraper).to receive(:run).and_return([calendar_event])
-      allow(OyakoHirobaScraper).to receive(:run).and_return([oyako_hiroba_event])
+      allow(OyakoHirobaScraper).to receive(:run).and_return([])
 
       KosodateEventIntegrator.run
 
       events = KosodateEvent.all
-      expect(events.count).to eq(2)
+      expect(events.count).to eq(1)
     end
   end
 end

--- a/spec/modules/scrapers/calendar_scraper_spec.rb
+++ b/spec/modules/scrapers/calendar_scraper_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe CalendarScraper do
       expect(event.date.month).to eq(Date.today.month)
     end
 
+    example "親子ひろばは除外する" do
+      events = CalendarScraper.run
+
+      expect(events.any? { |event| event.name == "コミセン親子ひろば" }).to be_falsey
+    end
+
     # 実装は正しい。しかし4月分のカレンダーが白紙なので失敗する
     # スタブ作るか、、、うーむ
     example "来月の子育てイベント情報を取得する" do


### PR DESCRIPTION
## やったこと
- [x] 同日の親子ひろばが1つしか登録されないバグを修正
- [x] 統合時は単純にカレンダー + 親子ひろば にした

### バグ詳細
[コミセン親子ひろば](http://www.city.musashino.lg.jp/shiminsanka/kodomokatei/kodomoseisaku/1012272.html)が同日に複数開催される場合、[カレンダー](http://www.city.musashino.lg.jp/cgi-evt/event/event.cgi?year=2021&month=3&day=3&cate=7&target=0)には1つしか表示されない。
そのためスクレイピング結果を突き合わせる際に、最初の1つしか場所が反映されていないかった。

### 対応内容
- カレンダーのスクレイピング結果から親子ひろばを除く
- 親子ひろば側のスクレイピング結果をそのまま統合する

これにより、同日複数開催でも正しくDBに登録される。