### PR TITLE
形態素解析のためにnatto（mecab）をインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'aws-sdk-dynamodb'
 
 gem 'line-bot-api'
 gem 'nokogiri'
+gem 'natto'
 
 group :test do 
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
       activesupport (>= 5.0.0)
     faker (2.16.0)
       i18n (>= 1.6, < 2)
+    ffi (1.15.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
@@ -37,6 +38,8 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
+    natto (1.2.0)
+      ffi (>= 1.9.0)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -73,6 +76,7 @@ DEPENDENCIES
   factory_bot
   faker
   line-bot-api
+  natto
   nokogiri
   pry-byebug
   rspec


### PR DESCRIPTION
## やること
- [x] [natto](https://github.com/buruzaemon/natto)のインストール
- [ ] MeCabのインストール（Lambdaでの実行環境構築）
- [ ] nattoの動作確認

参考
https://dev.classmethod.jp/articles/aws-lambda-with-mecab/
https://qiita.com/rtaguchi/items/e6cb594196fa8186e9a2